### PR TITLE
Fix supplement bibliography path

### DIFF
--- a/paper/current/supp.tex
+++ b/paper/current/supp.tex
@@ -20,7 +20,7 @@
 
 % Refs
 \usepackage{biblatex}
-\addbibresource{../main.bib}
+\addbibresource{references.bib}
 
 \usepackage{url}
 
@@ -52,4 +52,3 @@
 \printbibliography{}
     
 \end{document} %}}}
-


### PR DESCRIPTION
## Summary
- point `paper/current/supp.tex` at the existing `references.bib` file
- remove the stale `../main.bib` reference that made forced supplement rebuilds report a missing bibliography source

## Validation
- `cd paper/current && latexmk -gg supp.tex`
- `make test` *(still fails on `main` because pre-existing archive/notebook files are collected as tests and require missing `gensim`)*